### PR TITLE
Swap Photo and CLI handbook URLs

### DIFF
--- a/contributor-orientation.php
+++ b/contributor-orientation.php
@@ -483,13 +483,13 @@ function get_teams() {
 			'name'          => esc_html__( 'CLI', 'wporg' ),
 			'description'   => esc_html__( 'The CLI Team develops, maintains, and documents WP-CLI, the official command line tool for interacting with and managing your WordPress sites.', 'wporg' ),
 			'icon'          => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><rect x="0" fill="none" width="20" height="20"/><g><path d="M17 7.2V3H3v7.1c2.6-.5 4.5-1.5 6.4-2.6.2-.2.4-.3.6-.5v3c-1.9 1.1-4 2.2-7 2.8V17h14V9.9c-2.6.5-4.4 1.5-6.2 2.6-.3.1-.5.3-.8.4V10c2-1.1 4-2.2 7-2.8z"/></g></svg>',
-			'url'           => 'https://make.wordpress.org/photos/handbook/',
+			'url'           => 'https://make.wordpress.org/cli/handbook/contributing',
 		),
 		'photos' => array(
 			'name'          => esc_html__( 'Photos', 'wporg' ),
 			'description'   => esc_html__( 'The Photo Directory Team moderates every photo submitted to the WordPress Photo Directory, maintains and improves the directory site itself, and provides resources and documentation to educate, encourage, and facilitate photo contributors.', 'wporg' ),
 			'icon'          => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M6 5V3H3v2h3Zm12 10V4H9L7 6H2v9h16Zm-4-5c0-1.66-1.34-3-3-3s-3 1.34-3 3 1.34 3 3 3 3-1.34 3-3Z" clip-rule="evenodd"/></svg>',
-			'url'           => 'https://make.wordpress.org/cli/handbook/contributing/',
+			'url'           => 'https://make.wordpress.org/photos/handbook/',
 		),
 		'core-performance' => array(
 			'name'          => esc_html__( 'Core Performance', 'wporg' ),

--- a/contributor-orientation.php
+++ b/contributor-orientation.php
@@ -489,7 +489,7 @@ function get_teams() {
 			'name'          => esc_html__( 'Photos', 'wporg' ),
 			'description'   => esc_html__( 'The Photo Directory Team moderates every photo submitted to the WordPress Photo Directory, maintains and improves the directory site itself, and provides resources and documentation to educate, encourage, and facilitate photo contributors.', 'wporg' ),
 			'icon'          => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M6 5V3H3v2h3Zm12 10V4H9L7 6H2v9h16Zm-4-5c0-1.66-1.34-3-3-3s-3 1.34-3 3 1.34 3 3 3 3-1.34 3-3Z" clip-rule="evenodd"/></svg>',
-			'url'           => 'https://make.wordpress.org/photos/handbook/',
+			'url'           => 'https://make.wordpress.org/photos/handbook/moderating-photos/',
 		),
 		'core-performance' => array(
 			'name'          => esc_html__( 'Core Performance', 'wporg' ),


### PR DESCRIPTION
PR swaps Photo and WP CLI teams' URLs. This will be partially addressed in #5.